### PR TITLE
Add images to assets precompile list

### DIFF
--- a/config/initializers/simplificator_infrastructure_assets.rb
+++ b/config/initializers/simplificator_infrastructure_assets.rb
@@ -1,0 +1,3 @@
+Rails.application.config.assets.precompile += %w( simplificator_infrastructure/errors/logo.png )
+Rails.application.config.assets.precompile += %w( simplificator_infrastructure/errors/error_404.png )
+Rails.application.config.assets.precompile += %w( simplificator_infrastructure/errors/error_generic.png )


### PR DESCRIPTION
Unless you overwrite the images in your app, you will get the following error:
Error during failsafe response: Asset was not declared to be precompiled in production.
